### PR TITLE
Add ability to set ssl option through env variable.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Greg Price <gprice@edx.org>
 Sarina Canelake <sarina@edx.org>
 Alexandre Dubus <alexandre.dubus@inria.fr>
 Alan Boudreault <alan@alanb.ca>
+Matjaz Gregoric <mtyaka@gmail.com>

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -20,6 +20,7 @@ common: &default_session
     max_retries: <%= ENV['MONGOID_MAX_RETRIES'] || 1 %>
     retry_interval: <%= ENV['MONGOID_RETRY_INTERVAL'] || 0 %>
     timeout: <%= ENV['MONGOID_TIMEOUT'] || 0.5 %>
+    ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
 
 production:
   sessions:


### PR DESCRIPTION
Makes it possible to use SSL for the mongo connections by setting the `MONGOID_USE_SSL` environment variable to `True`.

*Background*: A third-party Open edX installation for Harvard is using an externally hosted mongo cluster. Due to security policies, the connections from cs_comments_service to the mongo cluster are required to be encrypted. Mongoid supports ssl connections by setting the `ssl` parameter to true when initializing a connection. This change makes it possible to initialize PyMongo/Mongoid connections so that they are use SSL encryption by setting an environment variable (which is in turn set up by edx/configuration, see https://github.com/edx/configuration/pull/1944).
*Partner information*: Harvard, for a third-party Open edX installation
*Jira ticket*: https://openedx.atlassian.net/browse/OSPR-518