### PR TITLE
Allow pinned field to be updated via PUT

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -52,7 +52,7 @@ end
 
 put "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   filter_blocked_content params["body"]
-  thread.update_attributes(params.slice(*%w[title body closed commentable_id group_id thread_type]))
+  thread.update_attributes(params.slice(*%w[title body pinned closed commentable_id group_id thread_type]))
 
   if thread.errors.any?
     error 400, thread.errors.full_messages.to_json


### PR DESCRIPTION
@jimabramson Please review

For some reason, there's a separate pin endpoint that enforces that a user_id parameter is provided, even though it's not actually used for anything. I see no reason pinned and closed should have different behavior, so this just allows pinned to be set via a PUT just like closed.