### PR TITLE
Use bulk operation instead.

### DIFF
--- a/scripts/db/migrate-008-context.js
+++ b/scripts/db/migrate-008-context.js
@@ -3,9 +3,7 @@ db.contents.ensureIndex({ _type: 1, course_id: 1, context: 1, pinned: -1, create
 db.contents.ensureIndex({ _type: 1, commentable_id: 1, context: 1, pinned: -1, created_at: -1 }, {background: true})
 
 print ("Adding context to all comment threads where it does not yet exist\n");
-db.contents.update(
-    {_type: "CommentThread", context: {$exists: false}},
-    {$set: {context: "course"}},
-    {multi: true}
-);
+var bulk = db.contents.initializeUnorderedBulkOp();
+bulk.find( {_type: "CommentThread", context: {$exists: false}} ).update(  {$set: {context: "course"}} );
+bulk.execute();
 printjson (db.runCommand({ getLastError: 1, w: "majority", wtimeout: 5000 } ));


### PR DESCRIPTION
The bulk operation should be faster and more performant than doing the db.find.update

Docs here: http://docs.mongodb.org/v2.6/reference/method/Bulk.find.update/

@dianakhuang @macdiesel 