### PR TITLE
Pagination Improvements

### DIFF
--- a/presenters/thread.rb
+++ b/presenters/thread.rb
@@ -71,12 +71,13 @@ class ThreadPresenter
   #   response_count
   #     The total number of responses
   def get_paged_merged_responses(thread_id, responses, skip, limit)
-    response_ids = responses.only(:_id).sort({"sk" => 1}).to_a.map{|doc| doc["_id"]}
-    paged_response_ids = limit.nil? ? response_ids.drop(skip) : response_ids.drop(skip).take(limit)
+    responses = responses.only(:_id).sort({"sk" => 1}).limit(limit).skip(skip)
+    paged_response_ids = responses.to_a.map{|doc| doc["_id"]}
+    response_count = responses.limit(nil).skip(nil).count()
     content = Comment.where(comment_thread_id: thread_id).
       or({:parent_id => {"$in" => paged_response_ids}}, {:id => {"$in" => paged_response_ids}}).
       sort({"sk" => 1})
-    {"responses" => merge_response_content(content), "response_count" => response_ids.length}
+    {"responses" => merge_response_content(content), "response_count" => response_count}
   end
 
   # Takes content output from Mongoid in a depth-first traversal order and


### PR DESCRIPTION
@BenjiLee I was able to easily push one of the pagination components down to the DB level. This really needs some better test coverage for larger threads and we should do an evaluation to see if there is any performance increase.

I basically replaced a query that pulls all the response ID's in to memory and then merged and queried the results in to 2 db calls. One to get the requested page of responses and another to get the overall count of responses for the thread. 

This could possibly lead to improved performance on very large threads but degraded performance on smaller threads. 