### PR TITLE
changed timeout to 6 seconds

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 require "rack-timeout"
 use Rack::Timeout           # Call as early as possible so rack-timeout runs before other middleware.
-Rack::Timeout.timeout = 20
+Rack::Timeout.timeout = 6
 
 require './app'
 run Sinatra::Application


### PR DESCRIPTION
@jimabramson Any reason this needs to be 20? The django comment client's timeout is 5 seconds.

https://github.com/edx/edx-platform/blob/master/lms/lib/comment_client/utils.py#L85

FYI @macdiesel in case you had an opinion.