### PR TITLE
Updating bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
 services:
   - elasticsearch
 before_install:
+  - gem update bundler # Ensure we use the latest version of bundler. Travis' default version of outdated.
   - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.11.deb && sudo dpkg --force-confnew -i elasticsearch-0.90.11.deb && sudo service elasticsearch restart
   # Install mongo 2.6.4 according to http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
   # TODO: This won't be necessary when travis switches to 2.6 by default - see https://github.com/travis-ci/travis-ci/issues/2246

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: ruby
+
 rvm:
   - "1.9.3"
+
+cache: bundler
+
 services:
   - elasticsearch
+
 before_install:
   - gem update bundler # Ensure we use the latest version of bundler. Travis' default version of outdated.
   - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.11.deb && sudo dpkg --force-confnew -i elasticsearch-0.90.11.deb && sudo service elasticsearch restart
@@ -13,4 +18,5 @@ before_install:
   - sudo apt-get update -q
   - sudo apt-get install -y mongodb-org=2.6.4 mongodb-org-server=2.6.4 mongodb-org-shell=2.6.4 mongodb-org-mongos=2.6.4 mongodb-org-tools=2.6.4
   - mongo --version
+
 script: bundle exec rspec

--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Matjaz Gregoric <mtyaka@gmail.com>
 Ben McMorran <ben.mcmorran@gmail.com>
 Bill DeRusha <bill@edx.org>
 Brian Beggs <macdiesel@gmail.com>
+Clinton Blackburn <cblackburn@edx.org>


### PR DESCRIPTION
The bundler version on Travis is outdated and has issues installing the gems. Updating to latest version.