### PR TITLE
Running MongoDB and Elasticsearch as daemons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: ruby
 
 rvm:
@@ -5,18 +7,20 @@ rvm:
 
 cache: bundler
 
-services:
-  - elasticsearch
-
 before_install:
   - gem update bundler # Ensure we use the latest version of bundler. Travis' default version of outdated.
-  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.11.deb && sudo dpkg --force-confnew -i elasticsearch-0.90.11.deb && sudo service elasticsearch restart
-  # Install mongo 2.6.4 according to http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
-  # TODO: This won't be necessary when travis switches to 2.6 by default - see https://github.com/travis-ci/travis-ci/issues/2246
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-  - sudo apt-get update -q
-  - sudo apt-get install -y mongodb-org=2.6.4 mongodb-org-server=2.6.4 mongodb-org-shell=2.6.4 mongodb-org-mongos=2.6.4 mongodb-org-tools=2.6.4
-  - mongo --version
+
+  # Run Elasticsearch as a daemon
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.13.zip
+  - unzip elasticsearch-0.90.13.zip
+  - elasticsearch-0.90.13/bin/elasticsearch
+
+  # Run MongoDB as a daemon
+  - curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.11.tgz
+  - tar -zxf mongodb-linux-x86_64-2.6.11.tgz
+  - export PATH=mongodb-linux-x86_64-2.6.11/bin:$PATH
+  - mkdir -p ./mongo/db
+  - mkdir -p ./mongo/log
+  - mongod --fork --dbpath ./mongo/db --logpath ./mongo/log/mongodb.log
 
 script: bundle exec rspec

--- a/spec/api/comment_spec.rb
+++ b/spec/api/comment_spec.rb
@@ -169,12 +169,12 @@ describe "app" do
         Comment.all.select{|c| c.id == comment.id}.first.should be_nil
       end
       it "can delete a sub comment" do
-        parent = CommentThread.first.comments.first
-        sub_comment = parent.children.first
-        id = sub_comment.id
-        delete "/api/v1/comments/#{id}"
-        Comment.where(:id => id).should be_empty
-        parent.children.where(:id => id).should be_empty
+        child_comment = Comment.where(:parent.exists => true).first
+        parent_comment = child_comment.parent
+        delete "/api/v1/comments/#{child_comment.id}"
+
+        Comment.where(:id => child_comment.id).should be_empty
+        parent_comment.children.where(:id => child_comment.id).should be_empty
       end
       it "returns 400 when the comment does not exist" do
         delete "/api/v1/comments/does_not_exist"


### PR DESCRIPTION
Running these services as daemons so that we can take advantage of Travis' container-based infrastructure. One test had to be updated, most likely due to sorting not behaving as expected. All tests will be updated in the future to properly prepare test data, and not rely on sorting/querying.