### PR TITLE
MA-2419:threadPUT - make 'read' mutually exclusive to other fields

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -57,16 +57,10 @@ put "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   filter_blocked_content params["body"]
   thread.update_attributes(params.slice(*%w[title body pinned closed commentable_id group_id thread_type]))
 
-  # user_id is the owner for a thread, requested_user_id is the user requesting to update said thread
-  if params["requested_user_id"] and value_to_boolean(params["read"])
-    user = User.only([:id, :username, :read_states]).find_by(external_id: params["requested_user_id"])
-    user.mark_as_read(thread) if user
-  end
-
   if thread.errors.any?
     error 400, thread.errors.full_messages.to_json
   else
-    presenter = ThreadPresenter.factory(thread, user || nil)
+    presenter = ThreadPresenter.factory(thread, nil)
     presenter.to_hash.to_json
   end
 end

--- a/api/users.rb
+++ b/api/users.rb
@@ -74,3 +74,8 @@ put "#{APIPREFIX}/users/:user_id" do |user_id|
     user.to_hash.to_json
   end
 end
+
+post "#{APIPREFIX}/users/:user_id/read" do |user_id|
+  user.mark_as_read(source)
+  user.reload.to_hash.to_json
+end

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -614,7 +614,7 @@ describe "app" do
 
       before(:each) { init_without_subscriptions }
 
-      it "update information of comment thread and don't mark thread as read" do
+      it "updates information of comment thread" do
         thread = CommentThread.first
         comment = thread.comments.first
         comment.endorsed = true
@@ -631,35 +631,6 @@ describe "app" do
         comment.endorsed.should == false
         comment.endorsement.should == nil
         check_unread_thread_result_json(changed_thread, parse(last_response.body))
-      end
-      it "update information of comment thread and mark thread as read for owner user" do
-        thread = CommentThread.first
-        put "/api/v1/threads/#{thread.id}", body: "new body", title: "new title", commentable_id: "new_commentable_id", thread_type: "question", read: true, requested_user_id: thread.author.id
-        last_response.should be_ok
-        changed_thread = CommentThread.find(thread.id)
-        changed_thread.body.should == "new body"
-        changed_thread.title.should == "new title"
-        changed_thread.commentable_id.should == "new_commentable_id"
-        changed_thread.thread_type.should == "question"
-        user = User.find_by(external_id: thread.author.id)
-        json_response = parse(last_response.body)
-        check_thread_result_json(user, changed_thread, json_response)
-        json_response["read"].should == true
-      end
-      it "update information of comment thread and mark thread as read for non-owner user" do
-        thread = CommentThread.first
-        user = create_test_user(42)
-        put "/api/v1/threads/#{thread.id}", body: "new body", title: "new title", commentable_id: "new_commentable_id", thread_type: "question", read: true, requested_user_id: user.id
-        last_response.should be_ok
-        changed_thread = CommentThread.find(thread.id)
-        changed_thread.body.should == "new body"
-        changed_thread.title.should == "new title"
-        changed_thread.commentable_id.should == "new_commentable_id"
-        changed_thread.thread_type.should == "question"
-        user = User.find_by(external_id: user.id)
-        json_response = parse(last_response.body)
-        check_thread_result_json(user, changed_thread, json_response)
-        json_response["read"].should == true
       end
       it "returns 400 when the thread does not exist" do
         put "/api/v1/threads/does_not_exist", body: "new body", title: "new title"

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -361,5 +361,22 @@ describe "app" do
 
       include_examples "unicode data"
     end
+
+    describe "POST /api/v1/users/:user_id/read" do
+
+      before(:each) { setup_10_threads }
+
+      it "marks a thread as read for the user" do
+        thread = @threads["t0"]
+        user = create_test_user(42)
+        post "/api/v1/users/#{user.external_id}/read", source_type: "thread", source_id: thread.id
+        last_response.should be_ok
+        user.reload
+        read_states = user.read_states.where(course_id: thread.course_id).to_a
+        read_date = read_states.first.last_read_times[thread.id.to_s]
+        read_date.should >= thread.updated_at
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## [MA-2419](https://openedx.atlassian.net/browse/MA-2419)

Update Thread PUT to make 'read' field mutually exclusive to other update fields.
For thread PUT requests;
- update last activity date for thread field updates.
- do not update last activity date if PUT request is made to mark thread as read

### Testing
- [x] Unit

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @robrap 
- [x] Code review: @jcdyer 

### Post-review
- [x] Squash commits