### PR TITLE
MA-2139: Mark thread as read for leaner on thread/comment creation

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -77,6 +77,8 @@ post "#{APIPREFIX}/threads/:thread_id/comments" do |thread_id|
     error 400, comment.errors.full_messages.to_json
   else
     user.subscribe(thread) if bool_auto_subscribe
+    # Mark thread as read for owner user on comment creation
+    user.mark_as_read(thread)
     comment.to_hash.to_json
   end
 end

--- a/api/commentables.rb
+++ b/api/commentables.rb
@@ -42,11 +42,17 @@ post "#{APIPREFIX}/:commentable_id/threads" do |commentable_id|
   
   thread.author = user
   thread.save
+
   if thread.errors.any?
     error 400, thread.errors.full_messages.to_json
   else
+    # Mark thread as read for owner user on creation
+    user.mark_as_read(thread)
     user.subscribe(thread) if bool_auto_subscribe
-    presenter = ThreadPresenter.factory(thread, nil)
+
+    # Initialize ThreadPresenter; if non-null user is passed it also calculates
+    # user specific data on initialization such as thread "read" status
+    presenter = ThreadPresenter.factory(thread, user)
     thread = presenter.to_hash
     thread["resp_total"] = 0
     thread.to_json

--- a/api/comments.rb
+++ b/api/comments.rb
@@ -44,6 +44,8 @@ post "#{APIPREFIX}/comments/:comment_id" do |comment_id|
       error 400, comment.errors.full_messages.to_json
     else
       user.subscribe(comment.comment_thread) if bool_auto_subscribe
+      # Mark thread as read for owner user on response creation
+      user.mark_as_read(comment.comment_thread)
       sub_comment.to_hash.to_json
     end
   end

--- a/spec/api/comment_spec.rb
+++ b/spec/api/comment_spec.rb
@@ -155,7 +155,7 @@ describe 'Comment API' do
   end
 
   describe 'POST /api/v1/comments/:comment_id' do
-    it 'creates a sub comment to the comment' do
+    it 'creates a sub comment to the comment and marks thread as read for user' do
       comment = thread.comments.first
       previous_child_count = comment.children.length
       user = thread.author
@@ -172,6 +172,8 @@ describe 'Comment API' do
       sub_comment.course_id.should == course_id
       sub_comment.author.should == user
       sub_comment.child_count.should == 0
+
+      test_thread_marked_as_read(thread.id, user.id)
     end
 
     it 'returns 400 when the comment does not exist' do

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -666,7 +666,6 @@ describe "app" do
         thread = CommentThread.first
         comment = thread.comments.first
         comment.endorsed = true
-        comment.endorsement = {:user_id => "42", :time => DateTime.now}
         comment.save
         put "/api/v1/threads/#{thread.id}", body: "new body", title: "new title", commentable_id: "new_commentable_id", thread_type: "question"
         last_response.should be_ok
@@ -716,7 +715,7 @@ describe "app" do
       let :default_params do
         {body: "new comment", course_id: "1", user_id: User.first.id}
       end
-      it "create a comment to the comment thread" do
+      it "creates a comment to the comment thread and marks thread as read for user" do
         thread = CommentThread.first
         user = User.first
         orig_count = thread.comment_count
@@ -729,6 +728,8 @@ describe "app" do
         comment.should_not be_nil
         comment.author_id.should == user.id
         retrieved["child_count"].should == 0
+
+        test_thread_marked_as_read(thread.id, user.id)
       end
       it "allows anonymous comment" do
         thread = CommentThread.first

--- a/spec/api/commentable_spec.rb
+++ b/spec/api/commentable_spec.rb
@@ -125,11 +125,11 @@ describe 'app' do
       subject { post "/api/v1/#{commentable_id}/threads", parameters }
 
       shared_examples_for 'CommentThread creation API' do |context='course'|
-        it 'creates a new CommentThread' do
+        it 'creates a new CommentThread and marks it as read for owner user' do
           expect(CommentThread.count).to eq 0
 
           body = parse(subject.body)
-          expect(body).to include('read' => false,
+          expect(body).to include('read' => true,
                                   'unread_comments_count' => 0,
                                   'endorsed' => false,
                                   'resp_total' => 0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -409,3 +409,11 @@ def create_comment_thread_and_comments
 
   thread
 end
+
+def test_thread_marked_as_read(thread_id, user_id)
+  # get thread to assert its "read" status
+  get "/api/v1/threads/#{thread_id}", user_id: user_id
+  last_response.should be_ok
+  retrieved_thread = parse last_response.body
+  retrieved_thread["read"].should == true
+end


### PR DESCRIPTION
## [MA-2139](https://openedx.atlassian.net/browse/MA-2139)

Mark thread as read on thread and comment creation for leaner himself.
### Testing
- [x] Unit

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @jcdyer 
- [x] Code review: @robrap 

### Post-review
- [x] Squash commits