### PR TITLE
Handle comment context in cases of missing parent thread.

### DIFF
--- a/models/comment.rb
+++ b/models/comment.rb
@@ -141,7 +141,14 @@ class Comment < Content
   end
 
   def context
-    self.comment_thread_id ? self.comment_thread.context : nil
+    if self.comment_thread_id
+      t = CommentThread.find self.comment_thread_id
+      if t
+        t.context
+      end
+    end
+  rescue Mongoid::Errors::DocumentNotFound
+    nil
   end
 
   def course_context?

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -36,6 +36,14 @@ describe Comment do
         expect(comment.context).to eq("course")
       end
     end
+
+    context 'without valid parent thread' do
+      it 'returns nil' do
+        comment = make_comment(author, course_thread, "comment")
+        comment.comment_thread_id = 'not a thread'
+        expect(comment.context).to eq(nil)
+      end
+    end
   end
 
   describe '#course_context?' do
@@ -50,6 +58,14 @@ describe Comment do
       it 'returns true' do
         comment = make_comment(author, course_thread, "comment")
         expect(comment.course_context?).to be_true
+      end
+    end
+
+    context 'without valid parent thread' do
+      it 'returns false' do
+        comment = make_comment(author, course_thread, "comment")
+        comment.comment_thread_id = 'not a thread'
+        expect(comment.course_context?).to be_false
       end
     end
   end
@@ -68,6 +84,15 @@ describe Comment do
         expect(comment.standalone_context?).to be_false
       end
     end
+
+    context 'without valid parent thread' do
+      it 'returns false' do
+        comment = make_comment(author, course_thread, "comment")
+        comment.comment_thread_id = 'not a thread'
+        expect(comment.standalone_context?).to be_false
+      end
+    end
+
   end
 
   describe '#child_count' do


### PR DESCRIPTION
### Description
 
[TNL-4944](https://openedx.atlassian.net/browse/TNL-4944)

Add more error-checking when getting the parent comment thread for comments.

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @robrap 

### Post-review
- [x] Squash commits


