### PR TITLE
Thread parent thread to child comments before serialization.

### DIFF
--- a/spec/presenters/thread_spec.rb
+++ b/spec/presenters/thread_spec.rb
@@ -153,7 +153,7 @@ describe ThreadPresenter do
     end
   end
 
-  context "#merge_response_content" do
+  context "#build_response_tree" do
 
     before(:each) { @cid_seq = 10 }
 
@@ -172,7 +172,7 @@ describe ThreadPresenter do
       c010 = make_comment(c01)
 
       pres = ThreadPresenter.new(nil, nil, nil, nil, nil)
-      responses = pres.merge_response_content([c0, c00, c01, c010])
+      responses = pres.build_response_tree(nil, [c0, c00, c01, c010])
       responses.size.should == 1 # c0
       responses[0]["id"].should == c0.id
       responses[0]["children"].size.should == 2 # c00, c01
@@ -194,7 +194,7 @@ describe ThreadPresenter do
       # be silently skipped over.
 
       pres = ThreadPresenter.new(nil, nil, nil, nil, nil)
-      responses = pres.merge_response_content([c00, c000, c1, c10, c111])
+      responses = pres.build_response_tree(nil, [c00, c000, c1, c10, c111])
       responses.size.should == 1 # c1
       responses[0]["id"].should == c1.id
       responses[0]["children"].size.should == 1 # c10


### PR DESCRIPTION
Normally, as a thread is being rendered, it goes through every child comment (or whatever comments are in the pagination range) and serializes them as it's properly ordering them, etc.

When these comments are serialized, they aren't fully materialized: many relations are still unpopulated until the given fields are first accessed.  For comments, a field that is accessed during serialization in the 'comment_thread', or the ID of the comment's parent.

This operation, even if it uses the query cache, is still slow.  It goes through reconstituting the object, which hits many mixins and other helper code used to provide the ORM-like facilities over our usage of MongoDB.

Since we ipso facto have the parent thread of a given comment during thread serialization, we now send it through the various calls that are used to reorder the child comments before everything is rendered to JSON.

This way, none of the magic that happens to lazy load this relation occurs, and we don't reconstitute documents from BSON, or anything of the other magical bits, because the field is pre-populated, in essence.  This saves a lot of work when rendering many comments in a given time slice of a thread.