### PR TITLE
MA-2678: replace use of 'updated_at' for 'read' state

### DIFF
--- a/models/comment.rb
+++ b/models/comment.rb
@@ -25,6 +25,7 @@ class Comment < Content
 
   index({author_id: 1, course_id: 1})
   index({_type: 1, comment_thread_id: 1, author_id: 1, updated_at: 1})
+  index({comment_thread_id: 1, author_id: 1, created_at: 1})
 
   index_name Content::ES_INDEX_NAME
 
@@ -53,7 +54,6 @@ class Comment < Content
 
   before_destroy :destroy_children
   before_create :set_thread_last_activity_at
-  before_update :set_thread_last_activity_at
   before_save :set_sk
 
   def self.hash_tree(nodes)

--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -68,7 +68,6 @@ class CommentThread < Content
   validates_presence_of :author, autosave: false
 
   before_create :set_last_activity_at
-  before_update :set_last_activity_at, :unless => lambda { closed_changed? }
   after_update :clear_endorsements
   before_destroy :destroy_subscriptions
 

--- a/presenters/thread_utils.rb
+++ b/presenters/thread_utils.rb
@@ -27,11 +27,11 @@ module ThreadUtils
         threads.each do |t|
           thread_key = t._id.to_s
           if read_dates.has_key? thread_key
-            is_read = read_dates[thread_key] >= t.updated_at
+            is_read = read_dates[thread_key] >= t.last_activity_at
             unread_comment_count = Comment.collection.find(
               :comment_thread_id => t._id,
               :author_id => {"$ne" => user.id},
-              :updated_at => {"$gte" => read_dates[thread_key]},
+              :created_at => {"$gte" => read_dates[thread_key]}
               ).count
             read_states[thread_key] = [is_read, unread_comment_count]
           end

--- a/scripts/db/migrate-009-comment_thread-author-created_at-indexes.js
+++ b/scripts/db/migrate-009-comment_thread-author-created_at-indexes.js
@@ -1,0 +1,1 @@
+db.contents.ensureIndex({ comment_thread_id: 1, author_id: 1, created_at: 1 }, { background: true })

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -175,7 +175,7 @@ describe "app" do
         end
 
         it "by activity" do
-          asc_order = [0, 2, 5, 1, 3, 4]
+          asc_order = [0, 1, 2, 3, 4, 5]
           check_sort("activity", "asc", asc_order)
           check_sort("activity", "desc", asc_order.reverse)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -214,11 +214,11 @@ def check_thread_result(user, thread, hash, is_json=false)
       read_date = read_states.first.last_read_times[thread.id.to_s]
       if read_date
         thread.comments.each do |c|
-          if c.updated_at < read_date
+          if c.created_at < read_date
             expected_unread_cnt -= 1
           end
         end
-        hash["read"].should == (read_date >= thread.updated_at)
+        hash["read"].should == (read_date >= thread.last_activity_at)
       else
         hash["read"].should == false
       end


### PR DESCRIPTION
### Description
 
[MA-2678](https://openedx.atlassian.net/browse/MA-2678)

To calculate 'read' status;
- for posts used 'last_acitvity_at' instead of 'updated_at'.
- for responses/comments used 'created_at' instead of 'updated_at'

Changed post/response/comment behaviour to update 'last_activity_at' only at time of creation.
Added a new index in migration script.
`db.contents.ensureIndex({ comment_thread_id: 1, author_id: 1, created_at: 1 }, { background: true })`

P.S:
Adding the new index in load test `create_indexes.js` is part of another PR https://github.com/edx/edx-load-tests/pull/62 which will be used for performance testing and the results of tests should be accepted before merging this PR.

### Testing
- [x] Unit
- [x] Performance

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @robrap 
- [x] Code review: @jcdyer 
- [x] Review new index: @tobz 

### Devops assistance
- [x] @edx/devops  to review new index created on forums
- [ ] File a support ticket to create the new index on stage/prod environments by emailing support@edx.org

cc: @BenjiLee 

### Post-review
- [x] Squash commits