### PR TITLE
Switch to using MongoDB 3.0 in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ before_install:
   - elasticsearch-0.90.13/bin/elasticsearch
 
   # Run MongoDB as a daemon
-  - curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.11.tgz
-  - tar -zxf mongodb-linux-x86_64-2.6.11.tgz
-  - export PATH=mongodb-linux-x86_64-2.6.11/bin:$PATH
+  - curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.12.tgz
+  - tar -zxf mongodb-linux-x86_64-3.0.12.tgz
+  - export PATH=mongodb-linux-x86_64-3.0.12/bin:$PATH
   - mkdir -p ./mongo/db
   - mkdir -p ./mongo/log
-  - mongod --fork --dbpath ./mongo/db --logpath ./mongo/log/mongodb.log
+  - mongod --fork --dbpath ./mongo/db --logpath ./mongo/log/mongodb.log --storageEngine wiredTiger
 
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'rest-client'
 
 group :test do
   gem 'codecov', :require => false
-  gem 'database_cleaner', '~> 1.5.1'
+  gem 'mongoid_cleaner', '~> 1.2.0'
   gem 'factory_girl', '~> 4.0'
   gem 'faker', '~> 1.6'
   gem 'guard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,6 @@ GEM
       url
     coderay (1.0.7)
     dalli (2.1.0)
-    database_cleaner (1.5.1)
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)
     delayed_job_mongoid (2.2.0)
@@ -85,6 +84,8 @@ GEM
     mongoid-compatibility (0.3.1)
       activesupport
       mongoid (>= 2.0)
+    mongoid_cleaner (1.2.0)
+      mongoid (>= 4.0)
     mongoid_magic_counter_cache (1.1.1)
       mongoid
       rake
@@ -173,7 +174,6 @@ DEPENDENCIES
   bundler
   codecov
   dalli
-  database_cleaner (~> 1.5.1)
   delayed_job
   delayed_job_mongoid
   enumerize
@@ -184,6 +184,7 @@ DEPENDENCIES
   i18n
   mongoid (~> 5.0.0)
   mongoid-tree!
+  mongoid_cleaner (~> 1.2.0)
   mongoid_magic_counter_cache
   newrelic_rpm
   nokogiri (~> 1.6.8)
@@ -204,3 +205,9 @@ DEPENDENCIES
   unicorn
   will_paginate_mongoid (~> 2.0)
   yajl-ruby
+
+RUBY VERSION
+   ruby 1.9.3p551
+
+BUNDLED WITH
+   1.12.5

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,14 +1,12 @@
-require 'database_cleaner'
+require 'mongoid_cleaner'
 
 RSpec.configure do |config|
   config.before(:suite) do
-    # Mongoid only supports truncation.
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.clean_with(:truncation)
+    MongoidCleaner.strategy = :drop
   end
 
   config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
+    MongoidCleaner.cleaning do
       example.run
     end
   end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -6,11 +6,8 @@ RSpec.configure do |config|
   FactoryGirl.find_definitions
 
   config.before(:suite) do
-    begin
-      DatabaseCleaner.start
+    MongoidCleaner.cleaning do
       FactoryGirl.lint
-    ensure
-      DatabaseCleaner.clean
     end
   end
 end


### PR DESCRIPTION
Now that we're on MongoDB 3.0 in production, we should also be testing with MongoDB 3.0.