### PR TITLE
Wait 10s after starting ElasticSearch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.13.zip
   - unzip elasticsearch-0.90.13.zip
   - elasticsearch-0.90.13/bin/elasticsearch
+  - sleep 10
 
   # Run MongoDB as a daemon
   - curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.12.tgz


### PR DESCRIPTION
Now that MongoDB 3.0 seems to download/untar faster than 2.6, we seem to be right over the line of how quickly ES can start up and be listening for connections, which leads the tests to try and connect too quickly, which fails.

By sleeping for 10 seconds after starting ElasticSearch, it's almost a certainty it will be up and running by the time we try to first connect to it.