### PR TITLE
Use proper relations instead of forcefully loading relations by hand.

### DIFF
--- a/models/comment.rb
+++ b/models/comment.rb
@@ -117,35 +117,22 @@ class Comment < Content
   end
 
   def commentable_id
-    #we need this to have a universal access point for the flag rake task
-    if self.comment_thread_id
-      t = CommentThread.find self.comment_thread_id
-      if t
-        t.commentable_id
-      end
-    end
+    return nil unless self.comment_thread
+    self.comment_thread.commentable_id
   rescue Mongoid::Errors::DocumentNotFound
     nil
   end
 
   def group_id
-    if self.comment_thread_id
-      t = CommentThread.find self.comment_thread_id
-      if t
-        t.group_id
-      end
-    end
+    return nil unless self.comment_thread
+    self.comment_thread.group_id
   rescue Mongoid::Errors::DocumentNotFound
     nil
   end
 
   def context
-    if self.comment_thread_id
-      t = CommentThread.find self.comment_thread_id
-      if t
-        t.context
-      end
-    end
+    return nil unless self.comment_thread
+    self.comment_thread.context
   rescue Mongoid::Errors::DocumentNotFound
     nil
   end


### PR DESCRIPTION
Some of the ways comments are accessed in the User model (when a complete user object is requested) lead to an N+1 situation because while we preload the related documents (preloading the parent thread of a given comment, in this case), further accesses to those comments actually never take advantage of the preloaded relations.

We should be using the relation directly, which will still act the same as before but allow us to actually benefit from preloading.