### PR TITLE
Add the ability to request a thread without its responses.

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -49,7 +49,7 @@ get "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   else
     resp_limit = nil
   end
-  presenter.to_hash(true, resp_skip, resp_limit, bool_recursive).to_json
+  presenter.to_hash(bool_with_responses, resp_skip, resp_limit, bool_recursive).to_json
 end
 
 put "#{APIPREFIX}/threads/:thread_id" do |thread_id|

--- a/presenters/thread.rb
+++ b/presenters/thread.rb
@@ -23,7 +23,7 @@ class ThreadPresenter
     @is_endorsed = is_endorsed
   end
 
-  def to_hash with_responses=false, resp_skip=0, resp_limit=nil, recursive=true
+  def to_hash(with_responses=false, resp_skip=0, resp_limit=nil, recursive=true)
     raise ArgumentError unless resp_skip >= 0
     raise ArgumentError unless resp_limit.nil? or resp_limit >= 1
     h = @thread.to_hash

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -513,6 +513,18 @@ describe "app" do
         check_thread_result_json(nil, thread, parsed)
       end
 
+      context 'when requesting the thread for informational purposes' do
+        subject do
+          get "/api/v1/threads/#{thread.id}", with_responses: false # we're asking for no responses here.
+        end
+
+        it 'should have no children' do
+          expect(subject).to be_ok
+          parsed = parse(subject.body)
+          expect(parsed).not_to include('children')
+        end
+      end
+
       context 'when marking as read' do
         subject do
           get "/api/v1/threads/#{thread.id}", {:user_id => thread.author.id, :mark_as_read => true}


### PR DESCRIPTION
For cases where we don't need or want the responses on a thread at all, like getting some metadata about a thread, we should be able to request it without the responses.  This exists in the `ThreadPresenter` but didn't exist as an option that could be passed in the API call itself.

We've added this as an option now -- `with_responses` -- that defaults to `true`, which preserves the existing behavior but does in fact allow toggling.

This gives us a backwards-compatible upgrade path to allow changes to be made the LMS so that requests which don't need the responses, or do need the responses, can be explicit about what they want.