### PR TITLE
Run tests using the es and mongo containers with docker-compose.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache: bundler
 
 before_install:
   - docker-compose -f docker-compose-travis.yml up -d
-  - docker exec forum_testing chmod +x /edx/app/forum/cs_comments_service/.travis/run_tests.sh
 
 script:
   - docker exec forum_testing /edx/app/forum/cs_comments_service/.travis/run_tests.sh

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,27 +1,10 @@
 #!/bin/bash -xe
 . /edx/app/forum/forum_env
 . /edx/app/forum/ruby_env
+export MONGOHQ_URL="mongodb://mongo.edx:27017/cs_comments_service_test"
+
+cd /edx/app/forum/cs_comments_service
 
 gem update bundler # Ensure we use the latest version of bundler. Travis' default version of outdated.
-
-# install java
-curl -L -C - -b "oraclelicense=accept-securebackup-cookie" -O http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz
-tar -xvzf jdk-8u111-linux-x64.tar.gz -C /opt
-export JAVA_HOME=/opt/jdk1.8.0_111/
-export PATH=/opt/jdk1.8.0_111/bin:$PATH
-
-# Run Elasticsearch as a daemon
-curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.13.zip
-unzip elasticsearch-0.90.13.zip
-elasticsearch-0.90.13/bin/elasticsearch
-sleep 10
-
-# Run MongoDB as a daemon
-curl -O https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.12.tgz
-tar -zxf mongodb-linux-x86_64-3.0.12.tgz
-export PATH=mongodb-linux-x86_64-3.0.12/bin:$PATH
-mkdir -p ./mongo/db
-mkdir -p ./mongo/log
-mongod --fork --dbpath ./mongo/db --logpath ./mongo/log/mongodb.log --storageEngine wiredTiger
 
 bundle exec rspec

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -24,9 +24,7 @@ test:
   clients:
     default:
       <<: *default_client
-      database: cs_comments_service_test
-      hosts:
-        - localhost:27017
+      <<: *default_uri
 
 production:
   clients:

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -2,11 +2,16 @@
 version: "2"
 
 services:
+  elasticsearch:
+    image: edxops/elasticsearch:latest
+    container_name: "es.edx"
+  mongo:
+    image: mongo:3.0.12
+    container_name: "mongo.edx"
   forum:
     image: edxops/forums:latest
 
     container_name: forum_testing
     volumes:
       - .:/edx/app/forum/cs_comments_service
-      - $HOME/.gem:/edx/app/forum/.gem
     command: tail -f /dev/null


### PR DESCRIPTION
@bilalahmad99 Here is how far I got.  I'm going to try to catch up with you early our morning, middle of your day I think. But feel free to merge this so you can work on top of it.  The biggest changes is making the elasticsearch and mongo services come up in their own containers in docker-compose.  The containers get addresses based on their names which mostly match the defaults.  I had to tweak how the forums pull in the config for testing so it works correctly.  This is working for me locally but may need tweaks to get fully done in travis.