### PR TITLE
Make the ruby linking error go away.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ language: ruby
 rvm:
   - "1.9.3"
 
-cache: bundler
-
-before_install:
+install:
   - docker-compose -f docker-compose-travis.yml up -d
 
 script:

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,11 +1,8 @@
 #!/bin/bash -xe
 . /edx/app/forum/forum_env
-. /edx/app/forum/ruby_env
 export MONGOHQ_URL="mongodb://mongo.edx:27017/cs_comments_service_test"
 
 cd /edx/app/forum/cs_comments_service
-
-gem update bundler # Ensure we use the latest version of bundler. Travis' default version of outdated.
 
 bundle install
 


### PR DESCRIPTION
The core issue was that if you don't provide an install step travis
tries to do its default action which generates a bunch of ruby code
that is linked to the ruby on the host system instead of the ruby in
the container.