### PR TITLE
Fix typo in search:do_reindex task

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -71,7 +71,7 @@ namespace :search do
       # NOTE on the small chance that another process re-auto-creates the index
       # we just deleted before we have a chance to create the alias, this next
       # call will fail.
-      move_alias_to(Content::ES_INDEX_NAME, new_index_name)
+      move_alias_to(Content::ES_INDEX_NAME, new_index)
     end
 
     op = in_place ? 'reindex' : '(re)build index'


### PR DESCRIPTION
This change fixes a small typo in the `search:reindex` rake task.

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP - want to get into the Ficus release candidate.

**Testing instructions**:

1. On your edxapp devstack, checkout this branch under `cs_comments_services`.
1. Run:

    ```
    vagrant@precise64:~$ sudo su forum
    forum@precise64:~/cs_comments_service$ rake search:rebuild
    ```

    Should complete without error.  Without this patch, the following error is displayed: 

    ```
    forum@precise64:~/cs_comments_service$ rake search:rebuild
    /edx/app/forum/cs_comments_service/lib/tasks/flags.rake:6: warning: already initialized constant ROOT
    /edx/app/forum/cs_comments_service/lib/tasks/kpis.rake:7: warning: already initialized constant ROOT
    /edx/app/forum/cs_comments_service/models/constants.rb:2: warning: already initialized constant COURSE_ID
    W, [2017-01-10T03:47:50.851265 #6483]  WARN -- : Overwriting existing field _id in class User.
    I, [2017-01-10T03:47:50.869685 #6483]  INFO -- : Creating new index: content_20170110034750...
    I, [2017-01-10T03:47:51.213440 #6483]  INFO -- : Applying index mappings for CommentThread
    I, [2017-01-10T03:47:51.312162 #6483]  INFO -- : Applying index mappings for Comment
    I, [2017-01-10T03:47:51.332436 #6483]  INFO -- : ...done!
    W, [2017-01-10T03:47:51.336931 #6483]  WARN -- : deleting auto-created index to make room for the alias
    rake aborted!
    NameError: undefined local variable or method `new_index_name' for main:Object
    /edx/app/forum/cs_comments_service/lib/tasks/search.rake:74:in `do_reindex'
    /edx/app/forum/cs_comments_service/lib/tasks/search.rake:158:in `block (2 levels) in <top (required)>'
    Tasks: TOP => search:rebuild
    (See full trace by running task with --trace)
    ```

**Reviewers**
- [x] @haikuginger 
- [x] edX reviewer[s] TBD