### PR TITLE
TNL-6118: Fix rebuild by loading app.rb in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,6 @@ require 'bundler'
 Bundler.setup
 Bundler.require
 
-application_yaml = ERB.new(File.read('config/application.yml')).result()
-
-
 begin
   require 'rspec/core/rake_task'
 
@@ -17,28 +14,13 @@ rescue LoadError
   # no rspec available
 end
 
-Tire.configure do
-  url YAML.load(application_yaml)['elasticsearch_server']
-end
-
 LOG = Logger.new(STDERR)
 
 desc 'Load the environment'
 task :environment do
-  environment = ENV['SINATRA_ENV'] || 'development'
-  Sinatra::Base.environment = environment
-  Mongoid.load!('config/mongoid.yml')
-  Mongoid.logger.level = Logger::INFO
-  module CommentService
-    class << self;
-      attr_accessor :config;
-    end
-  end
-
-  CommentService.config = YAML.load(application_yaml)
-
-  Dir[File.dirname(__FILE__) + '/lib/**/*.rb'].each { |file| require file }
-  Dir[File.dirname(__FILE__) + '/models/*.rb'].each { |file| require file }
+  # Load all of app.rb, because it is too easy to introduce bugs otherwise where Rake
+  # does not have a fix or config that is added to app.rb.
+  require File.dirname(__FILE__) + '/app.rb'
 end
 
 Dir.glob('lib/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
There are fixes needed for ES that existed in app.rb, that weren't loaded in the Rakefile environment.  Rather than attempt to pick and choose, which may lead to future errors of this sort, this just naively loads app.rb from Rake.

This means that:
1. We need special code in the newer PR to [skip code in app.rb when initializing the index](https://github.com/edx/cs_comments_service/pull/216/commits/8f2cd94cc1544f7863c15599809855af649ed35f).
2. We are definitely loading code that we don't need for Rake.
3. Do we need to retest all of Rake tasks using rake itself?  If this works, it seems simpler than either duplicating code (as was done before) or creating some other common rb file to load into both, which may lead to the same kind of bug if code is put in the wrong place.

Thoughts?

@dianakhuang @clintonb @maxrothman  