### PR TITLE
TNL-6447: Make search:initialize idempotent.

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -9,8 +9,6 @@ bundle install
 # allow dependent services to finish start up (e.g. ElasticSearch, Mongo)
 sleep 10
 
-bin/rake search:initialize
-
 # Use 'bin/rspec -fd' to print test names for debugging
 # Printing test names can be especially helpful for tracking down test
 # failure differences between Travis and Mac, because tests are loaded

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ Install the requisite gems:
 
     $ bundle install
 
+To initialize the index:
+
 Setup the search index. Note that the command below creates an alias with a unique name (e.g.
 content_20161220185820323), and assigns it a known alias: content. If you choose not to use the command below, you
 should still opt to reference your index by an alias rather than the actual index name. This will enable you to swap out
@@ -44,11 +46,13 @@ indices (e.g. rebuild_index) without having to take downtime or modify code with
 
     $ bin/rake search:initialize
 
-To rebuild a new index without moving the alias and without running catchup, do the following:
+To validate the 'content' alias exists and contains the proper mappings:
 
 .. code-block:: bash
 
-    $ bin/rake search:rebuild_index
+    $ bin/rake search:validate_index
+
+To rebuild the index:
 
 To rebuild a new index from the database and then point the alias 'content' to it, you can use the
 rebuild_index task. This task will also run catchup before and after the alias is moved, to minimize time where the
@@ -56,7 +60,13 @@ alias does not contain all documents.
 
 .. code-block:: bash
 
-    $ bin/rake search:rebuild_index[true]
+    $ bin/rake search:rebuild_index
+
+To rebuild a new index without moving the alias and without running catchup, use the following:
+
+.. code-block:: bash
+
+    $ bin/rake search:rebuild_index[false]
 
 You can also adjust the batch size (e.g. 200) and the sleep time (e.g. 2 seconds) between batches to lighten the load
 on MongoDB.

--- a/Rakefile
+++ b/Rakefile
@@ -16,9 +16,6 @@ end
 
 LOG = Logger.new(STDERR)
 
-# Indicates whether this is being run from within a 'search:' task in rake.
-RAKE_SEARCH = (Rake.application.top_level_tasks.select {|task| task.include? 'search:'}).any?
-
 desc 'Load the environment'
 task :environment do
   # Load all of app.rb to keep rake and the app as similar as possible.

--- a/app.rb
+++ b/app.rb
@@ -48,10 +48,12 @@ Mongo::Logger.logger.level = ENV["ENABLE_MONGO_DEBUGGING"] ? Logger::DEBUG : Log
 # Setup Elasticsearch
 # NOTE (CCB): If you want to see all data sent to Elasticsearch (e.g. for debugging purposes), set the tracer argument
 # to the value of a logger.
-# Example: Elascisearch.Client.new(tracer: get_logger('elasticsearch.tracer'))
+# Example: Elasticsearch::Client.new(tracer: get_logger('elasticsearch.tracer'))
+# NOTE: You can also add a logger, but it will log some FATAL warning during index creation.
+# Example: Elasticsearch::Client.new(logger: get_logger('elasticsearch', Logger::WARN))
 Elasticsearch::Model.client = Elasticsearch::Client.new(
     host: CommentService.config[:elasticsearch_server],
-    logger: get_logger('elasticsearch', Logger::WARN)
+    log: false
 )
 
 # Setup i18n
@@ -70,14 +72,6 @@ end
 Dir[File.dirname(__FILE__) + '/lib/**/*.rb'].each { |file| require file }
 Dir[File.dirname(__FILE__) + '/models/*.rb'].each { |file| require file }
 Dir[File.dirname(__FILE__) + '/presenters/*.rb'].each { |file| require file }
-
-
-$check_index_mapping_exists = defined?(RAKE_SEARCH) === nil || RAKE_SEARCH === false
-if $check_index_mapping_exists
-  # Ensure Elasticsearch index mappings exist, unless we are creating it in the rake search initialize
-  Comment.put_search_index_mapping
-  CommentThread.put_search_index_mapping
-end
 
 # Comment out observers until notifications are actually set up properly.
 #Dir[File.dirname(__FILE__) + '/models/observers/*.rb'].each {|file| require file}

--- a/models/concerns/searchable.rb
+++ b/models/concerns/searchable.rb
@@ -10,14 +10,6 @@ module Searchable
     after_update :update_indexed_document
     after_destroy :delete_document
 
-    def self.put_search_index_mapping(index=nil)
-      index ||= self.index_name
-      success = self.__elasticsearch__.client.indices.put_mapping(index: index, type: self.document_type, body: self.mappings.to_hash)
-      unless success
-        logger.warn "WARNING! could not apply search index mapping for #{self.name}"
-      end
-    end
-
     def as_indexed_json(options={})
       # TODO: Play with the `MyModel.indexes` method -- reject non-mapped attributes, `:as` options, etc
       self.as_json(options.merge root: false)

--- a/spec/lib/task_helpers_spec.rb
+++ b/spec/lib/task_helpers_spec.rb
@@ -86,7 +86,27 @@ describe TaskHelpers do
 
         Elasticsearch::Model.client.search(index: alias_name)['hits']['total'].should be > 0
       end
-
     end
+
+    context("#validate_index") do
+      include_context 'search_enabled'
+
+      subject { TaskHelpers::ElasticsearchHelper.validate_index(Content::ES_INDEX_NAME) }
+
+      it "validates the 'content' alias exists with proper mappings" do
+        subject
+      end
+
+      it "fails if the alias doesn't exist" do
+        TaskHelpers::ElasticsearchHelper.delete_index(Content::ES_INDEX_NAME)
+        expect{subject}.to raise_error(RuntimeError)
+      end
+
+      it "fails if the alias has the wrong mappings" do
+        Elasticsearch::Model.client.indices.delete_mapping(index: Content::ES_INDEX_NAME, type: Comment.document_type)
+        expect{subject}.to raise_error(RuntimeError)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## [TNL-6447](https://openedx.atlassian.net/browse/TNL-6447)

### Description

The original intent of this code was to make search:initialize idempotent.  

Additionally, we added rake tasks for:
- validate_index (used to validate index and mappings)
- put_mappings (used to potentially update mappings on an existing index)

### Sandbox
- [X] sandbox ([https://robrap.sandbox.edx.org/](https://robrap.sandbox.edx.org/))

### Testing
- [X] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @maxrothman 
- [x] Code review: @dianakhuang 

FYI: @clintonb 

### Post-review
- [x] Rebase and squash commits