### PR TITLE
TNL-6464: Minor changes to rebuild_index.

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -11,12 +11,18 @@ namespace :search do
   end
 
   desc 'Rebuilds a new index of all data from the database and then updates alias.'
-  task :rebuild_index, [:call_move_alias, :batch_size, :sleep_time] => :environment do |t, args|
-    args.with_defaults(:call_move_alias => false)
+  task :rebuild_index, [:call_move_alias, :batch_size, :sleep_time, :extra_catchup_minutes] => :environment do |t, args|
+    args.with_defaults(:call_move_alias => true)
     args.with_defaults(:batch_size => 500)
-    args.with_defaults(:sleep_time => 0)
-    alias_name = args[:call_move_alias] ? Content::ES_INDEX_NAME : nil
-    TaskHelpers::ElasticsearchHelper.rebuild_index(alias_name, args[:batch_size].to_i, args[:sleep_time].to_i)
+    args.with_defaults(:sleep_time => 0)  # sleep time between batches in seconds
+    args.with_defaults(:extra_catchup_minutes => 5) # additional catchup time in minutes
+    alias_name = args[:call_move_alias] === true ? Content::ES_INDEX_NAME : nil
+    TaskHelpers::ElasticsearchHelper.rebuild_index(
+        alias_name,
+        args[:batch_size].to_i,
+        args[:sleep_time].to_i,
+        args[:extra_catchup_minutes].to_i
+    )
   end
 
   desc 'Generate a new, empty physical index, without bringing it online.'

--- a/spec/lib/tasks/search_rake_spec.rb
+++ b/spec/lib/tasks/search_rake_spec.rb
@@ -11,21 +11,22 @@ describe "search:rebuild_index" do
   its(:prerequisites) { should include("environment") }
 
   it "calls rebuild_index with defaults" do
-    TaskHelpers::ElasticsearchHelper.should_receive(:rebuild_index).with(nil, 500, 0)
+    TaskHelpers::ElasticsearchHelper.should_receive(:rebuild_index).with(Content::ES_INDEX_NAME, 500, 0, 5)
 
     subject.invoke
   end
 
   it "calls rebuild_index with arguments" do
     # Rake calls receive arguments as strings.
-    call_move_alias = 'true'
+    call_move_alias = 'false'
     batch_size = '100'
     sleep_time = '2'
+    extra_catchup_minutes = '10'
     TaskHelpers::ElasticsearchHelper.should_receive(:rebuild_index).with(
-          Content::ES_INDEX_NAME, batch_size.to_i, sleep_time.to_i
+          nil, batch_size.to_i, sleep_time.to_i, extra_catchup_minutes.to_i
     )
 
-    subject.invoke(call_move_alias, batch_size, sleep_time)
+    subject.invoke(call_move_alias, batch_size, sleep_time, extra_catchup_minutes)
   end
 end
 


### PR DESCRIPTION
## [TNL-6464](https://openedx.atlassian.net/browse/TNL-6464)

### Description

Minor changes to rebuild_index rake task:
- Default to moving alias and running catchup.
- Allow configurable extra minutes for catchup.

### Sandbox
- skipping unless a reviewer wants this.

### Testing
- [X] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @dianakhuang 
- [ ] Code review: @maxrothman 

### Post-review
- [ ] Rebase and squash commits