### PR TITLE
Verify that ES is configured properly before starting

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,11 @@
 require 'tmpdir'
+
+# Load app.rb to get all dependencies.
+require 'app.rb'
+
+# Make sure elasticsearch is configured correctly
+UnicornHelpers.exit_on_invalid_index
+
 worker_processes Integer(ENV['WORKER_PROCESSES'] || 4)
 timeout 25
 preload_app true

--- a/config/unicorn_tcp.rb
+++ b/config/unicorn_tcp.rb
@@ -1,4 +1,11 @@
 require 'tmpdir'
+
+# Load app.rb to get all dependencies.
+require 'app.rb'
+
+# Make sure elasticsearch is configured correctly
+UnicornHelpers.exit_on_invalid_index
+
 worker_processes Integer(ENV['WORKER_PROCESSES'] || 4)
 timeout 25
 preload_app true

--- a/lib/unicorn_helpers.rb
+++ b/lib/unicorn_helpers.rb
@@ -1,0 +1,16 @@
+module UnicornHelpers
+
+  # Make sure elasticsearch is configured correctly
+  def self.exit_on_invalid_index
+    begin
+      TaskHelpers::ElasticsearchHelper.validate_index(Content::ES_INDEX_NAME)
+    rescue => e
+      # Magic exit code expected by forum-supervisor.sh for when
+      # rake search:validate_index fails
+      STDERR.puts "ERROR: ElasticSearch configuration validation failed. "\
+           "\"rake search:validate_index\" failed with the following message: #{e.message}"
+      exit(101)
+    end
+  end
+
+end

--- a/spec/lib/unicorn_helpers_spec.rb
+++ b/spec/lib/unicorn_helpers_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'elasticsearch'
+
+describe UnicornHelpers do
+  include_context 'search_enabled'
+
+  context("#exit_on_invalid_index") do
+    subject { UnicornHelpers.exit_on_invalid_index }
+
+    it "doesn't exit when index is valid" do
+      # code 101 is special code recongnized by forum-supervisor.sh
+      lambda{subject}.should_not exit_with_code(101)
+    end
+
+    it "exits when index is invalid" do
+      TaskHelpers::ElasticsearchHelper.delete_index(Content::ES_INDEX_NAME)
+      # code 101 is special code recongnized by forum-supervisor.sh
+      lambda{subject}.should exit_with_code(101)
+    end
+
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -5,3 +5,26 @@ RSpec::Matchers.define :be_an_empty_response do
     actual.body == '{}'
   end
 end
+
+RSpec::Matchers.define :exit_with_code do |exp_code|
+  actual = nil
+
+  match do |block|
+    begin
+      block.call
+    rescue SystemExit => e
+      actual = e.status
+    end
+    actual and actual == exp_code
+  end
+  failure_message_for_should do |block|
+    "expected block to call exit(#{exp_code}) but exit" +
+        (actual.nil? ? " not called" : "(#{actual}) was called")
+  end
+  failure_message_for_should_not do |block|
+    "expected block not to call exit(#{exp_code})"
+  end
+  description do
+    "expect block to call exit(#{exp_code})"
+  end
+end


### PR DESCRIPTION
Run the rake search:validate task before starting the service. If it
fails, then that means the mappings or indexes aren't in sync, the
former of which can cause corrupt data, and the latter, non-functioning
search. It fails with this exit code so that supervisor knows whether to
sleep before trying to restar the app or not.

Should merge simultaneously with https://github.com/edx/configuration/pull/3689