### PR TITLE
Install newrelic_rpm to < 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,8 @@ group :test do
   gem 'webmock', '~> 1.22'
 end
 
-gem 'newrelic_rpm'
+# FIXME Remove version restriction once ruby upgraded to 2.x
+gem 'newrelic_rpm', '~> 3.16.0'
 gem 'unicorn'
 gem "rack-timeout"
 gem "i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ DEPENDENCIES
   mongoid-tree!
   mongoid_cleaner (~> 1.2.0)
   mongoid_magic_counter_cache
-  newrelic_rpm
+  newrelic_rpm (~> 3.16.0)
   nokogiri (~> 1.6.8)
   protected_attributes
   pry


### PR DESCRIPTION
[NewRelic have dropped support for ruby 1.9.x](https://discuss.newrelic.com/t/support-for-ruby-jruby-1-x-is-being-deprecated-in-ruby-agent-4-0-0/44787), and so we can't use their latest app monitoring agent until we upgrade ruby.

This change fixes the version to `newrelic_rpm (3.16.0)`, which is needed until the ruby 2.x upgrade is complete (planned for [Gingko](https://openedx.atlassian.net/wiki/display/COMM/Ginkgo)).

**JIRA tickets**: [OSPR-1688](https://openedx.atlassian.net/browse/OSPR-1688)

**Sandbox URL**:

* LMS: https://forums-pr237.sandbox.opencraft.hosting/
* Studio: https://studio-forums-pr237.sandbox.opencraft.hosting/

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP - New Relic drops support at the end of February 2017.

**Testing instructions**:

1. Verify that a NewRelic agent 3.16.0 was deployed to the sandbox.
1. Verify that the forums application for the sandbox is being monitored on the NewRelic account.

**Reviewers**
- [x] @itsjeyd 
- [x] edX reviewer[s] TBD

**Settings**
```yaml
forum_version: "jill/newrelic_3.x"
forum_source_repo: "https://github.com/open-craft/cs_comments_service.git"
```