### PR TITLE
Install newrelic_rpm to < 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,8 @@ group :test do
   gem 'rspec', '~> 2.11.0'
 end
 
-gem 'newrelic_rpm'
+# FIXME Remove version restriction once ruby upgraded to 2.x
+gem 'newrelic_rpm', '~> 3.16.0'
 gem 'unicorn'
 gem "rack-timeout"
 gem "i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ DEPENDENCIES
   mongoid-tree!
   mongoid_cleaner (~> 1.2.0)
   mongoid_magic_counter_cache
-  newrelic_rpm
+  newrelic_rpm (~> 3.16.0)
   nokogiri (~> 1.6.8)
   protected_attributes
   pry


### PR DESCRIPTION
NewRelic have dropped support for ruby 1.9.x, and so we can't use their latest
app monitoring agent until we upgrade ruby.

ref https://discuss.newrelic.com/t/support-for-ruby-jruby-1-x-is-being-deprecated-in-ruby-agent-4-0-0/44787