### PR TITLE
Update development db to match others.

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -15,16 +15,14 @@ common_uri: &default_uri
 development:
   clients:
     default:
+      <<: *default_uri
       <<: *default_client
-      database: cs_comments_service_development
-      hosts:
-        - localhost:27017
 
 test:
   clients:
     default:
-      <<: *default_client
       <<: *default_uri
+      <<: *default_client
 
 production:
   clients:


### PR DESCRIPTION
The service is no longer authorized to edit a database of a different name,
so this changes the development database name to match the name of
other environments.

FYI: @jlajoie @feanil 