### PR TITLE
Fixed issues with app.rb require

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,7 +1,7 @@
 require 'tmpdir'
 
 # Load app.rb to get all dependencies.
-require 'app.rb'
+require File.expand_path('../../app.rb', __FILE__)
 
 # Make sure elasticsearch is configured correctly
 UnicornHelpers.exit_on_invalid_index

--- a/config/unicorn_tcp.rb
+++ b/config/unicorn_tcp.rb
@@ -1,7 +1,7 @@
 require 'tmpdir'
 
 # Load app.rb to get all dependencies.
-require 'app.rb'
+require File.expand_path('../../app.rb', __FILE__)
 
 # Make sure elasticsearch is configured correctly
 UnicornHelpers.exit_on_invalid_index


### PR DESCRIPTION
When trying to launch the app if the `LOAD_PATH` was not properly set
the unicorn server was unable to load the `app.rb` source
file. Updated to use the `expand_path` method from the File class.