### PR TITLE
Config/accept mongodb auth source

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -8,6 +8,7 @@ common: &default_client
     retry_interval: <%= ENV['MONGOID_RETRY_INTERVAL'] || 0 %>
     timeout: <%= ENV['MONGOID_TIMEOUT'] || 0.5 %>
     ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
+    auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] || 'test' %>
 
 common_uri: &default_uri
   uri: <%= ENV['MONGOHQ_URL'] %>

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -8,7 +8,8 @@ common: &default_client
     retry_interval: <%= ENV['MONGOID_RETRY_INTERVAL'] || 0 %>
     timeout: <%= ENV['MONGOID_TIMEOUT'] || 0.5 %>
     ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
-    auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] || 'test' %>
+    # not setting this env variable should result in backwards compatiblity
+    auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] %>
 
 common_uri: &default_uri
   uri: <%= ENV['MONGOHQ_URL'] %>


### PR DESCRIPTION
## Allow override on where the user is authenticated.

By default if no auth_source is passed, it will use the database the user is connecting too.

For some cloud providers (like Mongo Atlas), the user must be authenticated against 'admin' database even though they are accessing some other db.

The goal is to have a backwards compatible setting such that if the current users don't have this setting, it will continue to work.

Open to ideas if there is a better way to achieve this :)