### PR TITLE
fixed YONK-866:Deleting a post in discussions throws error

### DIFF
--- a/models/concerns/searchable.rb
+++ b/models/concerns/searchable.rb
@@ -27,7 +27,7 @@ module Searchable
     end
 
     def delete_document
-      __elasticsearch__.delete_document if CommentService.search_enabled?
+      __elasticsearch__.delete_document ignore: 404 if CommentService.search_enabled?
     end
   end
 end


### PR DESCRIPTION
Deleting a post with a response and a comment was throwing error in forum service. 
When a post is deleted it first deletes it's children(comments), and when elasticsearch tries to delete children in cs_comment_service it did not find the child and throws error. 
i have added "ignore: 404" and now if elasticsearch did not find a child, it will ignore the delete call for that child.