### PR TITLE
Handle non-existent user and missing param upon retiring user.

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -79,8 +79,14 @@ post "#{APIPREFIX}/users/:user_id/read" do |user_id|
 end
 
 post "#{APIPREFIX}/users/:user_id/retire" do |user_id|
-  return {}.to_json if not params["retired_username"]
-  user = User.find_by!(external_id: user_id)
+  if not params["retired_username"]
+    error 500, {message: "Missing retired_username param."}.to_json
+  end
+  begin
+    user = User.find_by(external_id: user_id)
+  rescue Mongoid::Errors::DocumentNotFound
+    error 404, {message: "User not found."}.to_json
+  end
   user.update_attribute(:email, "")
   user.update_attribute(:notification_ids, [])
   user.update_attribute(:read_states, [])

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -409,6 +409,16 @@ describe "app" do
         init_without_subscriptions
       end
 
+      it "attempts to retire a user without sending retired_username" do
+        post "/api/v1/users/1/retire"
+        expect(last_response.status).to eq(500)
+      end
+
+      it "attempts to retire a non-existent user" do
+        post "/api/v1/users/1234/retire", retired_username: "retired_user_test"
+        expect(last_response.status).to eq(404)
+      end
+
       it "retires a user and all the user's data" do
         retired_username = "retired_user_ABCD1234"
         user = User.where(external_id: '1').first


### PR DESCRIPTION
Fix for: https://openedx.atlassian.net/browse/EDUCATOR-2854
