### PR TITLE
require the newrelic_rpm group when NEW_RELIC_ENABLE is set

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,8 +2,15 @@ require 'rubygems'
 require 'bundler'
 require 'erb'
 
+groups = [:default]
+
+# optionally add newrelic
+if ENV["NEW_RELIC_ENABLE"]
+  groups.push(:newrelic_rpm)
+end
+
 Bundler.setup
-Bundler.require
+Bundler.require(*groups)
 
 logger = Logger.new(STDOUT)
 logger.level = Logger::WARN


### PR DESCRIPTION
We suspect newrelic is not being loaded because the "newrelic_rpm" group
is not being specified.  We cannot blindly load it because the open
source community rightly demands independence from newrelic, so we
conditionally load it.