### PR TITLE
Build travis push on master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ services:
 
 language: ruby
 
+branches:
+  only:
+    - master
+
 rvm:
   - "2.4.1"
 


### PR DESCRIPTION
I've been working on adding some automation for creating and testing openedx releases, which creates branches in a number of IDA's, and (if desired) deletes them at the end of the tests. For now, the job is in the beginning stages, and just creates a branch, and later deletes it.

The problem is, the branch gets deleted so quickly, that travis gets kicked off, but quickly fails when the branch can't be found. To make matters worse, since the branch doesn't include any new commits, travis gets run (and fails) on the same commit as the tip of the master branch, which overwrites whatever status it previously had to failing (example: link to failing travis build).

This change fixes that, by following a travis pattern we currently already use in other repos, like these: (configuration repo, devstack repo). This will limit builds to being triggered either by a pull request, or a push to master.

So when any non-master branch gets created or pushed, travis will not be triggered (unless there is an open pull request for that branch).