### PR TITLE
Update new relic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Ben McMorran <ben.mcmorran@gmail.com>
 Bill DeRusha <bill@edx.org>
 Brian Beggs <macdiesel@gmail.com>
 Clinton Blackburn <cblackburn@edx.org>
+Awais Jibran <awaisdar001@gmail.com>

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     multipart-post (2.0.0)
     nenv (0.3.0)
     netrc (0.11.0)
-    newrelic_rpm (5.1.0.344)
+    newrelic_rpm (5.6.0.349)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)


### PR DESCRIPTION
### [EDUCATOR-3733](https://openedx.atlassian.net/browse/EDUCATOR-3733)
Update NewRelic on forums. 

As NewRelic_Rpm was not pinned to any specific version, I  just have to run the `bundle update newrelic_rpm` to update to the latest version of newrelic gem. 
As I do not have much context about ruby and its gems, I am going to ask for the Cambridge review. 

