### PR TITLE
[SE-886] Upgrade unicorn to 5.3.1 to fix GC error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    unicorn (5.3.0)
+    unicorn (5.3.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     url (0.3.2)


### PR DESCRIPTION
On one of our AWS instances, forum service is failing with errors like the following when a request is made to it:

```
/edx/app/forum/.gem/ruby/2.4.0/gems/unicorn-5.3.0/lib/unicorn/http_request.rb:80:in `parse': method `hash' called on unexpected T_IMEMO object (0x0055c77a4c6b60 flags=0x707a) (NotImplementedError)
--
from /edx/app/forum/.gem/ruby/2.4.0/gems/unicorn-5.3.0/lib/unicorn/http_request.rb:80:in `read'
from /edx/app/forum/.gem/ruby/2.4.0/gems/unicorn-5.3.0/lib/unicorn/http_server.rb:606:in `process_client'
from /edx/app/forum/.gem/ruby/2.4.0/gems/unicorn-5.3.0/lib/unicorn/http_server.rb:702:in `worker_loop'
from /edx/app/forum/.gem/ruby/2.4.0/gems/unicorn-5.3.0/lib/unicorn/http_server.rb:549:in `spawn_missing_workers'
from /edx/app/forum/.gem/ruby/2.4.0/gems/unicorn-5.3.0/lib/unicorn/http_server.rb:142:in `start'
from /edx/app/forum/.gem/ruby/2.4.0/gems/unicorn-5.3.0/bin/unicorn:126:in `<top (required)>'
from /edx/app/forum/cs_comments_service/bin/unicorn:16:in `load'
from /edx/app/forum/cs_comments_service/bin/unicorn:16:in `<main>'
```

A similar issue was reported on the unicorn mailing list: https://bogomips.org/unicorn-public/20140722163900.GA1032@dcvr.yhbt.net/t/.

> This is either a version mismatch from objects of different Ruby versions
or memory corruption caused by a C extension.  Since your install
hasn't been touched in a week, I suspect a buggy C extension.

Unicorn [v5.3.1](https://github.com/defunkt/unicorn/commits/v5.3.1) has a [fix](https://github.com/defunkt/unicorn/commit/50ca22510c2a64c11628f5c89eac5dd47ebc9f5f) for a GC related issue. Updating to it prevents further occurrences of this error. This fix is the only change between 5.3.0 and 5.31.

We would also like this cherry-picked into the ironwood branch.