### PR TITLE
handle_threads_query helper method optimized to increase performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'mongoid-tree', :git => 'https://github.com/macdiesel/mongoid-tree'
 gem 'rs_voteable_mongo', :git => 'https://github.com/navneet35371/voteable_mongo.git'
 gem 'mongoid_magic_counter_cache'
 
+# Before updating will_paginate version, we need to make sure that property 'total_entries'
+# exists otherwise use updated property name to fetch total collection count on line 228
+# of lib/helpers.rb.
 gem 'will_paginate_mongoid', "~>2.0"
 gem 'rdiscount'
 gem 'nokogiri', "~>1.8.1"

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ gem 'rs_voteable_mongo', :git => 'https://github.com/navneet35371/voteable_mongo
 gem 'mongoid_magic_counter_cache'
 
 # Before updating will_paginate version, we need to make sure that property 'total_entries'
-# exists otherwise use updated property name to fetch total collection count on line 228
-# of lib/helpers.rb.
+# exists otherwise use updated property name to fetch total collection count in lib/helpers.rb's
+# function 'handle_threads_query'.
 gem 'will_paginate_mongoid', "~>2.0"
 gem 'rdiscount'
 gem 'nokogiri', "~>1.8.1"


### PR DESCRIPTION
'handle_threads_query' helper method optimized to increase performance. Previously it was fetching count of collection thrice and that was costly operation when performed on big comments/threads collection. Optimized code now fetches count only once. 
YONK-1177 contains all the details. 