### PR TITLE
[BB-1289] Add support for configuring auth_source for Mongo connection

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -8,6 +8,7 @@ common: &default_client
     retry_interval: <%= ENV['MONGOID_RETRY_INTERVAL'] || 0 %>
     timeout: <%= ENV['MONGOID_TIMEOUT'] || 0.5 %>
     ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
+    auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] || '' %>
 
 common_uri: &default_uri
   uri: <%= ENV['MONGOHQ_URL'] %>


### PR DESCRIPTION
Allows specifying an `auth_source` parameter for MongoDB. 

This can be configured via: https://github.com/edx/configuration/pull/5195
A similar PR for edx-platform: https://github.com/edx/edx-platform/pull/20819