### PR TITLE
Revert "Upgraded mongo ruby driver"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'yajl-ruby', '~> 1.3.1'
 gem 'activemodel', '~> 4.2.8'
 
 gem 'mongoid', '~> 5.0.0'
-gem 'bson'
+gem 'bson', '~> 3.1'
 gem 'bson_ext'
 gem 'protected_attributes'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    bson (4.7.0)
+    bson (3.2.6)
     bson_ext (1.5.1)
     builder (3.2.3)
     codecov (0.1.10)
@@ -105,8 +105,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.10.2)
-    mongo (2.11.2)
-      bson (>= 4.6.0, < 5.0.0)
+    mongo (2.1.2)
+      bson (~> 3.0)
     mongoid (5.0.0)
       activemodel (~> 4.0)
       mongo (~> 2.1)
@@ -216,7 +216,7 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel (~> 4.2.8)
-  bson
+  bson (~> 3.1)
   bson_ext
   bundler
   codecov
@@ -257,5 +257,8 @@ DEPENDENCIES
   will_paginate_mongoid (~> 2.0)
   yajl-ruby (~> 1.3.1)
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
-   1.17.3
+   1.16.1


### PR DESCRIPTION
Reverts edx/cs_comments_service#287
Forums are not working on stage after merging this PR.
Error: "undefined method `select_server' for {"mode"=>:primary}:BSON::Document"
This error was supposed to be fixed in version 2.5 but it seems to be occurring in 2.11 as well.
https://jira.mongodb.org/browse/RUBY-1235

New relic errors:
<img width="1063" alt="Screen Shot 2019-12-31 at 3 56 46 PM" src="https://user-images.githubusercontent.com/10988308/71620133-fb32b480-2be9-11ea-9309-ff3ee47ec7bc.png">
