### PR TITLE
Revert upgrade mongo ruby driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'yajl-ruby', '~> 1.3.1'
 gem 'activemodel', '~> 4.2.8'
 
 gem 'mongoid', '~> 5.0.0'
-gem 'bson'
+gem 'bson', '~> 3.1'
 gem 'bson_ext'
 gem 'protected_attributes'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    bson (4.7.0)
+    bson (3.2.6)
     bson_ext (1.5.1)
     builder (3.2.3)
     codecov (0.1.10)
@@ -105,8 +105,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.10.2)
-    mongo (2.5.3)
-      bson (>= 4.3.0, < 5.0.0)
+    mongo (2.1.2)
+      bson (~> 3.0)
     mongoid (5.0.0)
       activemodel (~> 4.0)
       mongo (~> 2.1)
@@ -216,7 +216,7 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel (~> 4.2.8)
-  bson
+  bson (~> 3.1)
   bson_ext
   bundler
   codecov
@@ -261,4 +261,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.17.3
+   1.16.1


### PR DESCRIPTION
## [PROD-1087](https://openedx.atlassian.net/browse/PROD-1087)

### Description
Revert upgrade mongo db ruby driver. The driver was upgraded to 2.5.3 which is the earliest version that is compatible with mongo 3.6 but it is still producing errors on stage.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 

### Post-review
- [ ] Rebase and squash commits