### PR TITLE
Fixed mongo cursor not found

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -312,7 +312,7 @@ helpers do
 
     #now build a thread to users subscription map
     subscriptions_map = {}
-    subscriptions.each do |s|
+    subscriptions.no_timeout.each do |s|
       if not subscriptions_map.keys.include? s.source_id.to_s
         subscriptions_map[s.source_id.to_s] = []
       end


### PR DESCRIPTION
## [PROD-1087](https://openedx.atlassian.net/browse/PROD-1087)

### Description
Fix cursor not found error caused during mongodb driver upgrade.
The previous [PR](https://github.com/edx/cs_comments_service/pull/298) was merged and deployed to stage but there are some errors there. I have looked into the details of the error. There seems to be only one endpoint that is causing an issue.

New Relic Error:

https://rpm.newrelic.com/accounts/88178/applications/3343672/traced_errors/f0806c1f-53ab-11ea-a5a4-0242ac110008_34611_41003

I have looked into the details of the error trace and also tried to reproduce the issue locally but it is not reproducible.  The endpoint with the issue is covered by test cases as well and there are no test failures. 

Looking into the details of the error it seems it is being caused during a mongo db operation and I have searched a bit about it and it seems to be caused by a timeout during this line of code. I am assuming since there is not enough data locally that is why the timeout does not occur locally. I have a looked into possible solutions to fix the error and I have added a “no_timeout” method into the code which can possibly fix this. I have not tested the solution as it is not reproducible locally but I think this is something we can try to fix the error.



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @bderusha 

### Post-review
- [ ] Rebase and squash commits