### PR TITLE
Revert "Fixed mongo cursor not found"

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -312,7 +312,7 @@ helpers do
 
     #now build a thread to users subscription map
     subscriptions_map = {}
-    subscriptions.no_timeout.each do |s|
+    subscriptions.each do |s|
       if not subscriptions_map.keys.include? s.source_id.to_s
         subscriptions_map[s.source_id.to_s] = []
       end


### PR DESCRIPTION
Reverts edx/cs_comments_service#308