### PR TITLE
CRI-171 Makes the mongo authentication mechanism configurable from the environment

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -13,6 +13,8 @@ services:
     container_name: forum_testing
     volumes:
       - ..:/edx/app/forum/cs_comments_service
+    environment:
+      MONGOID_AUTH_MECH: ""
   forum:
     extends: forum-base
     command: tail -f /dev/null

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -9,6 +9,7 @@ common: &default_client
     timeout: <%= ENV['MONGOID_TIMEOUT'] || 0.5 %>
     ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
     auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] || '' %>
+    auth_mech: <%= ENV['MONGOID_AUTH_MECH'].nil? ? ':scram' : ENV['MONGOID_AUTH_MECH'] %>
 
 common_uri: &default_uri
   uri: <%= ENV['MONGOHQ_URL'] %>


### PR DESCRIPTION
Allows the mongo client's `auth_mech` to be configured from the environment and via ansible.

**JIRA tickets**: [CRI-186](https://openedx.atlassian.net/browse/CRI-186), [OSPR-4402](https://openedx.atlassian.net/browse/OSPR-4402), [SE-2321](https://tasks.opencraft.com/browse/SE-2321)

**Discussions**: [Discussion forum errors in latest master with mongo 3.2](https://discuss.openedx.org/t/discussion-forum-errors-in-latest-master-with-mongo-3-2/1843/5)

**Dependencies**: Relates to https://github.com/edx/configuration/pull/5755

**Sandbox URL**:

* LMS: https://forumpr316.sandbox.opencraft.hosting/
* Studio: https://studio.forumpr316.sandbox.opencraft.hosting/

**Merge deadline**: ASAP, fix needed for Juniper.

**Testing instructions**:

Devstack:
1. Check out this branch under your `<DOCKER>/cs_comments_service` repo.
1. Checkout the branch for https://github.com/edx/devstack/pull/519
1. Rebuild the forum container:
   ```bash
   (devstack) :devstack/ $ docker-compose up  --detach  --force-recreate forum
   ```
1. Ensure that you can post to the forum in a course on your devstack.

Sandbox:
1. Login to the sandbox
1. Visit the edX Demo course's Discussion forum
1. Ensure you can post to the forum with no errors.
1. Visit a unit with a discussion inline unit.
1. Ensure you can post to the forum with no errors.

**Author Notes & Concerns**

Ideally, we would set a `auth_mech` in `mongoid.yml` `options` only if `ENV['MONGOID_AUTH_MECH']` is set, however, there's no way to express this in YAML.  If we want to make this value configurable, we have to set it to *something*, and all the available options cause a change to the authentication approach.

Here's a detailed explanation of the attempts made here, and why I ended up with what I did.

1. The only default [CI would accept](https://travis-ci.org/github/edx/cs_comments_service/builds/678031252) was `auth_mech: ""`.  This means "no authentication", and is required by CI because it [does not have user credentials in its connection string](https://travis-ci.org/github/edx/cs_comments_service/builds/678031252#L291):
   ```
   export MONGOHQ_URL=mongodb://mongo.edx:27017/cs_comments_service_test
   ```
1. Using [`:scram`](https://travis-ci.org/github/edx/cs_comments_service/builds/677977886#L569-L575) or [`:mongodb_cr`](https://travis-ci.org/github/edx/cs_comments_service/builds/678004020#L514-L518) as defaults caused CI authentication errors.
1. Also tried the empty symbol `:""` in an attempt to reduce configuration errors, but that is [not a valid option](https://travis-ci.org/github/edx/cs_comments_service/builds/678014377#L514-L515).

So ended up having to provide a [default configuration value of `:scram`](https://github.com/edx/configuration/pull/5755/files#diff-ee4067dcaeee71225ad181854d306b06R25), which is supported by Mongo>=3, removed in Mongo>=4, and works in the devstack.  OpenCraft needs `:mongodb_cr` as deployed to the sandbox here, because though we're running Mongo 3.2, we haven't upgraded our authentication mechanism yet.

**Reviewers**
- [ ] @toxinu
- [ ] edX reviewer[s] TBD

FYI @bderusha 

**Settings**
```yaml
FORUM_MONGO_AUTH_MECH: ":mongodb_cr"
```