### PR TITLE
bump version codecov to latest release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     bson (3.2.6)
     bson_ext (1.5.1)
     builder (3.2.3)
-    codecov (0.1.10)
+    codecov (0.2.11)
       json
       simplecov
       url


### PR DESCRIPTION
Codecov 0.1.x was yanked from rubygems, causing installation of cs_comments_service to fail. This bumps to the latest codecov version.