### PR TITLE
Reconnect MongoDB after failover

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -1,3 +1,5 @@
+require_relative '../mongoutil'
+
 post "#{APIPREFIX}/users" do
   user = User.new(external_id: params["id"])
   user.username = params["username"]
@@ -64,6 +66,7 @@ get "#{APIPREFIX}/users/:user_id/active_threads" do |user_id|
 end
 
 put "#{APIPREFIX}/users/:user_id" do |user_id|
+  reconnect_mongo_primary
   user = User.find_or_create_by(external_id: user_id)
   user.update_attributes(params.slice(*%w[username default_sort_key]))
   if user.errors.any?

--- a/models/user.rb
+++ b/models/user.rb
@@ -1,5 +1,7 @@
 require 'logger'
+
 require_relative 'constants'
+require_relative '../mongoutil'
 
 class User
   include Mongoid::Document
@@ -128,6 +130,7 @@ class User
     if source._id == self._id and source.class == self.class
       raise ArgumentError, "Cannot follow oneself"
     else
+      reconnect_mongo_primary
       Subscription.find_or_create_by(subscriber_id: self._id.to_s, source_id: source._id.to_s, source_type: source.class.to_s)
     end
   end
@@ -231,6 +234,7 @@ class User
 
 
   def mark_as_read(thread)
+    reconnect_mongo_primary
     read_state = read_states.find_or_create_by(course_id: thread.course_id)
     read_state.last_read_times[thread.id.to_s] = Time.now.utc
     read_state.save

--- a/mongoutil.rb
+++ b/mongoutil.rb
@@ -1,0 +1,36 @@
+def get_db_is_master
+  Mongoid::Clients.default.command(isMaster: 1)
+end
+
+def is_mongo_primary?
+  begin
+    response = get_db_is_master
+    return response.ok? &&
+      response.documents.first['ismaster'] == true
+  rescue
+    # ignored
+  end
+
+  false
+end
+
+def is_mongo_available?
+  begin
+    response = get_db_is_master
+    return response.ok? &&
+      (response.documents.first['ismaster'] == true ||
+       Mongoid::Clients.default.options[:read][:mode] != :primary)
+  rescue
+    # ignored
+  end
+
+  false
+end
+
+
+def reconnect_mongo_primary
+  begin
+    Mongoid::Clients.default.close
+    Mongoid::Clients.default.reconnect
+  end unless is_mongo_primary?
+end


### PR DESCRIPTION
The forum process stops working after a MongoDB replica failover, even when the MongoDB Ruby driver connects using read modes that allow for reading on secondaries.

After some investigation we found that there's a piece of Ruby code that ensures the server connected is the primary and returns a database failure in case it is not.

The approach was changed instead to reconnect to the primary during a heartbeat or when writing to MongoDB.

**Merge deadline**: ASAP

**Testing instructions**:

1. Check the [extended heartbeat](https://mongo-failover.opencraft.hosting/heartbeat?extended) to ensure everything works.
1. Request a failover (or SSH into the VM and use `rs.stepDown()` on a mongo shell connected to the primary local mongodb).
1. Create a new user to access the discussions, to ensure the forum creates a new user on first access.
1. Ensure the heartbeat works after the failover.
1. Try posting new threads, comments, subscribing etc.

**Reviewers**
- [ ] @aayushagra
- [ ] edX reviewer[s] TBD