### PR TITLE
Mongoid config is more forgiving

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -15,6 +15,9 @@ services:
   mongo:
     image: mongo:3.2.21
     container_name: "mongo.edx"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: supersecurepassword
   forum-base:
     image: edxops/forum:ruby257 # TODO: switch back to latest after configuration release
     container_name: forum_testing
@@ -35,6 +38,8 @@ services:
     depends_on:
       - "elasticsearch"
       - "mongo"
+    environment:
+      MONGOID_AUTH_SOURCE: admin
 
 volumes:
   data01:

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 . /edx/app/forum/forum_env
-export MONGOHQ_URL="mongodb://mongo.edx:27017/cs_comments_service_test"
+export MONGOHQ_URL="mongodb://root:supersecurepassword@mongo.edx:27017/cs_comments_service_test?authSource=admin"
 
 cd /edx/app/forum/cs_comments_service
 

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,12 @@
+{
+  "scanSettings": {
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -9,7 +9,7 @@ common: &default_client
     timeout: <%= ENV['MONGOID_TIMEOUT'] || 0.5 %>
     ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
     auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] || '' %>
-    auth_mech: <%= ENV['MONGOID_AUTH_MECH'].nil? ? ':scram' : ENV['MONGOID_AUTH_MECH'] %>
+    auth_mech: <%= ENV['MONGOID_AUTH_MECH'].blank? ? ':scram' : ENV['MONGOID_AUTH_MECH'] %>
 
 common_uri: &default_uri
   uri: <%= ENV['MONGOHQ_URL'] %>


### PR DESCRIPTION
This PR does the following

- Use `.blank?` to gracefully handle the case that the user may accidentally runs `export MONGOID_AUTH_MECH=""`
- Enable authentication for mongo in test environment.