### PR TITLE
Add new filters to the comments API [BD-38] [TNL-8796] [BB-4969]

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -61,7 +61,7 @@ get "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   unless (resp_limit <= size_limit)
     error 400, [t(:param_exceeds_limit, :param => resp_limit, :limit => size_limit)].to_json
   end
-  presenter.to_hash(bool_with_responses, resp_skip, resp_limit, bool_recursive).to_json
+  presenter.to_hash(bool_with_responses, resp_skip, resp_limit, bool_recursive, bool_flagged_comments).to_json
 end
 
 put "#{APIPREFIX}/threads/:thread_id" do |thread_id|

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -127,6 +127,10 @@ helpers do
     value_to_boolean params["anonymous_to_peers"]
   end
 
+  def bool_flagged_comments
+    value_to_boolean params["flagged_comments"]
+  end
+
   def handle_paged_threads_query(paged_comment_threads)
 
   end
@@ -209,9 +213,9 @@ helpers do
         threads = []
         skipped = 0
         to_skip = (page - 1) * per_page
-        has_more = false        
+        has_more = false
         thread_count = comment_threads.count
-        
+
         # batch_size is used to cap the number of documents we might load into memory at any given time
         comment_threads.batch_size(CommentService.config["manual_pagination_batch_size"].to_i).each do |thread|
          thread_key = thread._id.to_s
@@ -230,7 +234,7 @@ helpers do
 
         # The following trick makes frontend pagers work without recalculating
         # the number of all unread threads per user on every request (since the number
-        # of threads in a course could be tens or hundreds of thousands).  It has the 
+        # of threads in a course could be tens or hundreds of thousands).  It has the
         # effect of showing that there's always just one more page of results, until
         # there definitely are no more pages.  This is really only acceptable for pagers
         # that don't actually reveal the total number of pages to the user onscreen.
@@ -238,7 +242,7 @@ helpers do
       else
         # let the installed paginator library handle pagination
         page = [1, page].max
-        paginated_collection = comment_threads.paginate(:page => page, :per_page => per_page) 
+        paginated_collection = comment_threads.paginate(:page => page, :per_page => per_page)
         threads = paginated_collection.to_a
 
         # Before updating will_paginate gem version, we need to make sure that property 'total_entries'
@@ -389,7 +393,7 @@ helpers do
       return
     end
     if CommentService.blocked_hashes.include? hash then
-      msg = t(:blocked_content_with_body_hash, :hash => hash) 
+      msg = t(:blocked_content_with_body_hash, :hash => hash)
       logger.warn msg
       error 503, [msg].to_json
     end

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -559,6 +559,20 @@ describe 'app' do
         end
       end
 
+      context 'when filtering comments by flagged status' do
+        subject do
+          create(:comment, comment_thread: thread, abuse_flaggers: [1])
+          get "/api/v1/threads/#{thread.id}", flagged_comments: true
+        end
+
+        it 'returns only flagged comments' do
+          parsed = parse(subject.body)
+          for child in parsed["children"] do
+            expect(child["abuse_flaggers"]).not_to be_empty
+          end
+        end
+      end
+
       it 'returns 404 when the thread does not exist' do
         thread.destroy
         expect(subject.status).to eq 404

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -362,7 +362,7 @@ end
 # add standalone threads and comments to the @threads and @comments hashes
 # using the namespace "standalone t#{index}" for threads and "standalone t#{index} c#{i}" for comments
 # takes an index param if used within an iterator, otherwise will namespace using 0 for thread index
-# AKA this will overwrite "standalone t0" each time it is called. 
+# AKA this will overwrite "standalone t0" each time it is called.
 def make_standalone_thread_with_comments(author, index=0)
   thread = make_thread(
       author,
@@ -400,6 +400,39 @@ def setup_10_threads
     end
   end
   @default_order = 10.times.map { |i| "t#{i}" }.reverse
+end
+
+def setup_comments
+  User.all.delete
+  Content.all.delete
+
+  # create 2 courses
+  courses = ["abc", "def"]
+
+  # create 2 users
+  users = 2.times.map { |i| create_test_user(i+100) }
+
+  # create a thread author
+  author = create_test_user(99)
+
+  for course in courses
+    # create 5 threads per course
+    5.times do |i|
+      thread = make_thread(author, "#{course} t#{i}", course, "pdq")
+      # each user comments 5 times per thread
+      for user in users
+        # flag one random comment from each thread
+        flag = rand(5)
+        5.times do |j|
+          comment = make_comment(user, thread, "c#{course} t#{i} u#{user.id} c#{j}")
+          if j == flag
+            comment.abuse_flaggers = [1]
+            comment.save!
+          end
+        end
+      end
+    end
+  end
 end
 
 # Creates a CommentThread with a Comment, and nested child Comment.


### PR DESCRIPTION
Add a new endpoint to retrieve comments from an user in a specific course.

### New endpoint:

* `/api/v1/comments?user_id=<user_id>&course_id=<course_id>`
* `/api/v1/comments?user_id=<user_id>&course_id=<course_id>&flagged`

### Testing Instructions:

1. Setup a master devstack
2. Checkout this branch
3. Restart `cs_comments_service`
4. Post a few comments in the Discussions area with a test user
5. Retrieve the user's comments by calling the API with the user's and the course's IDs.

Example:
```bash
curl -H "X-Edx-Api-Key: password" "http://localhost:44567/api/v1/comments?user_id=1&course_id=course-v1:edX+DemoX+Demo_Course"
```

FYI -- @ormsbee & @benmcmorran 