### PR TITLE
feat: Add user course stats API [BD-38] [TNL-8795] [BB-4970]

### DIFF
--- a/.github/docker-compose-ci.yml
+++ b/.github/docker-compose-ci.yml
@@ -13,7 +13,7 @@ services:
       - data01:/usr/share/elasticsearch/data
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
   mongo:
-    image: mongo:3.2.21
+    image: mongo:4.2.14
     container_name: "mongo.edx"
   forum-base:
     image: edxops/forum:ruby257 # TODO: switch back to latest after configuration release


### PR DESCRIPTION
Adds a new API that returns the following stats about a user's participation in a course's discussion:
- The number of threads they have created.
- The number of responses they've posted on threads. 
- The number of replies they've made to responses. 
- The number of active flags/reports against the user.
- The number of inactive flags/reports against the user.

**JIRA tickets**: https://openedx.atlassian.net/browse/TNL-8795

**Dependencies**: 

**Testing instructions**:

1. Create a course with a set of users.
2. Make posts as different users, add responses and replies, and mark a few posts, comments, threads etc as flagged.
3. Unmark a few flags.
4. Check the API response and make sure it seems correct. 
5. Compare to the existing single-user API for this.

**Author notes and concerns**:
Currently, this includes anonymous posts as well. If a user has very few posts, and there are very few anonymous posts, this combination of factors could make it easy to determine if an anonymous post belongs to a particular user. 

One way to mitigate this is to not include anonymous posts in these stats. Another option is to include them only for staff users. 

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml

```