### PR TITLE
feat: Added configuration options for customizing Elasticsearch conne…

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -68,7 +68,9 @@ Mongo::Logger.logger.level = ENV["ENABLE_MONGO_DEBUGGING"] ? Logger::DEBUG : Log
 # Example: Elasticsearch::Client.new(logger: get_logger('elasticsearch', Logger::WARN))
 Elasticsearch::Model.client = Elasticsearch::Client.new(
     host: CommentService.config[:elasticsearch_server],
-    log: false
+    log: false,
+    port: CommentService.config[:elasticsearch_port],
+    transport_options: {ssl: {verify: CommentService.config[:elasticsearch_verify_ssl]}}
 )
 
 # Setup i18n

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,6 +1,8 @@
 level_limit: 3
 api_key: <%= ENV['API_KEY'] || 'PUT_YOUR_API_KEY_HERE' %>
 elasticsearch_server: <%= ENV['SEARCH_SERVER_ES7'] || 'http://localhost:9200' %>
+elasticsearch_port: <%= ENV['ELASTICSEARCH_PORT'] || 9200 %>
+elasticsearch_verify_ssl: <%= ENV['ELASTICSEARCH_VERIFY_SSL'] || true %>
 max_deep_search_comment_count: 5000
 enable_search: true
 default_locale: <%= ENV['SERVICE_LANGUAGE'] || 'en-US' %>


### PR DESCRIPTION
…ction

- Added an explicit parameter to set the TCP port for communicating with Elasticsearch. Otherwise it defaults to 9200 and there is no way to override that value. This prevents anyone from using an AWS managed cluster, as they default to using HTTPS port 443.
- Added a parameter to turn off SSL certificate validation. This again is useful for AWS managed clusters that default to HTTPS connections and where you want to use service discovery to handle the endpoint (e.g. Consul)

(cherry picked from commit 70a44a89dbade9814519450e38450439133308e0)